### PR TITLE
Removed check for long download paths over 260 characters on windows,…

### DIFF
--- a/src/browser.cpp
+++ b/src/browser.cpp
@@ -160,7 +160,6 @@ void Browser::on_syncPushButton_clicked()
 
     QItemSelection newSelection;
     ui->dataTreeView->collapseAll();
-    bool hasShownLongPathError = false;
 
     foreach(Structureelement *currentElement, elementList)
     {
@@ -178,17 +177,6 @@ void Browser::on_syncPushButton_clicked()
         QString directoryPath = Utils::getElementLocalPath(currentElement, downloadPath, false, false);
         QDir directory(directoryPath);
 
-        // prevent creation of paths with a length of more than 260 characters
-        if((directoryPath.length() + currentElement->text().length()) > 260 && QSysInfo::productType() == "windows")
-        {
-            if(!hasShownLongPathError)
-            {
-                Utils::errorMessageBox(tr("Pfad zu lang!"), tr("Pfad zur Datei enthält mehr als 260 Zeichen und kann daher nicht erstellt werden. "
-                                                              "Bitte ändere den Downloadverzeichnis auf einen Pfad mit weniger Zeichen! Datei wird übersprungen."));
-                hasShownLongPathError = true;
-            }
-            continue;
-        }
 
         // Ordner ggf. erstellen
         if(!directory.mkpath(directoryPath))


### PR DESCRIPTION
… since [Qt uses the long path api options in windows](https://forum.qt.io/topic/84796/does-qdir-impose-a-maximum-path-limit-on-windows/2) and thus handles them fine. (Addressing #15) 
The changes were tested on Windows 10.0.19041.