### PR TITLE
Prevent trailing/leading whitespaces

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -112,7 +112,7 @@ void Parser::parseMoodleFiles(QNetworkReply *reply, Structureelement* course)
 
         topicname = escapeString(file["topicname"].toString());
         modulename = escapeString(file["modulename"].toString());
-        filename = file["filename"].toString();
+        filename = file["filename"].toString().trimmed();
         sourceDirectory = file["sourceDirectory"].toString();
         filesize = fileInformation["filesize"].toInt();
         timestamp = file["lastModified"].toInt();


### PR DESCRIPTION
The current filename can contain leading and trailing whitespace. As [windows doesn't like such files](https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/file-folder-name-whitespace-characters) and Nextcloud won't sync them because of this reason, prevent this from happening.

![image](https://user-images.githubusercontent.com/50966627/209478302-3d0bc0c8-79ba-49fc-95cd-07eaec752273.png)
